### PR TITLE
adicionando parâmetro method: 'POST' no arquivo http-request-post.js …

### DIFF
--- a/Apostila/module-nodejs/pt-br/http.md
+++ b/Apostila/module-nodejs/pt-br/http.md
@@ -665,6 +665,7 @@ const postData = querystring.stringify({
 const options = {
         host: 'webschool-io.herokuapp.com'
       , path: '/api/pokemons'
+      , method: 'POST'
       , headers: {
           'Content-Type': 'application/x-www-form-urlencoded'
         , 'Content-Length': postData.length
@@ -743,5 +744,3 @@ E o cabeçalho `'Content-Length': postData.length` fala qual é o tamanho, em by
 # FIM
 
 Dica: [https://github.com/floatdrop/debug-http](https://github.com/floatdrop/debug-http)
-
-


### PR DESCRIPTION
Fiquei um tempo tentando descobrir porque não conseguia fazer um request post, após algum tempo descobri que no vídeo havia esse parâmetro (method: 'POST') que não estava no material do arquivo http.md
